### PR TITLE
Clean up the handling of the preauths delivered via `list_pending`

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -97,10 +97,10 @@ Vue.filter('currency', function (value) {
 	    "data": function() {
 		return {
 		    "selectedTab": 0,
-		    "request_tx": null,
+		    "request_preauth": null,
 		    "dialog_request_confirm_open": false,
 		    "dialog_request_decline_open": false,
-		    "promise_tx": null,
+		    "promise_preauth": null,
 		    "dialog_promise_confirm_open": false,
 		    "dialog_promise_decline_open": false,
 		};
@@ -174,44 +174,44 @@ Vue.filter('currency', function (value) {
 		pending_promise_amount: function ( tx ) {
 		    return parseFloat( tx.event[2].Promise.tx.amount );
 		},
-		dialog_request_confirm: function ( tx ) {
-		    this.request_tx			= tx;
+		dialog_request_confirm: function ( request_preauth ) {
+		    this.request_preauth		= request_preauth;
 		    this.dialog_request_confirm_open	= true;
 		},
-		dialog_request_decline: function ( tx ) {
-		    this.request_tx			= tx;
+		dialog_request_decline: function ( request_preauth ) {
+		    this.request_preauth		= request_preauth;
 		    this.dialog_request_decline_open	= true;
 		},
-		send_promise_for_request: function( request ) {
+		send_promise_for_request: function( request_preauth ) {
 		    notify.open({
 			type: 'info',
 			message: "Approving request",
 		    });
 		    this.$store.dispatch('approve_request', {
-                        request: request.event[0],
-                        ...request.event[2].Request
+                        request: request_preauth.event[0],
+                        ...request_preauth.event[2].Request
                     });
 		    notify.success("Funds have been promised");
-		    this.request_tx			= null;
+		    this.request_preauth		= null;
 		},
 		send_decline_for_request: function( request_hash ) {
 		    console.log( "Decline request", request_hash );
-		    this.request_tx			= null;
+		    this.request_preauth		= null;
 		    // this.$store.dispatch('decline_request', {
 		    // })
 		},
-		dialog_promise_confirm: function ( tx ) {
-		    this.promise_tx			= tx;
+		dialog_promise_confirm: function ( promise_preauth ) {
+		    this.promise_preauth		= promise_preauth;
 		    this.dialog_promise_confirm_open	= true;
 		},
-		dialog_promise_decline: function ( tx ) {
-		    this.promise_tx			= tx;
+		dialog_promise_decline: function ( promise_preauth ) {
+		    this.promise_preauth		= promise_preauth;
 		    this.dialog_promise_decline_open	= true;
 		},
-		send_receive_payment: function( tx ) {
-		    const promise			= tx.event[2].Promise
-		    const promise_sig			= "[signature]";
-		    const promise_commit		= tx.event[0];
+		send_receive_payment: function( promise_preauth ) {
+		    const promise			= promise_preauth.event[2].Promise
+		    const promise_sig			= promise_preauth.provenance[1];
+		    const promise_commit		= promise_preauth.event[0];
 		    
 		    notify.open({
 			type: 'info',
@@ -223,11 +223,11 @@ Vue.filter('currency', function (value) {
 			promise_commit,
 		    });
 		    notify.success("Payment received");
-		    this.promise_tx			= null;
+		    this.promise_preauth		= null;
 		},
 		send_decline_payment: function( request_hash ) {
 		    console.log( "Decline payment", request_hash );
-		    this.promise_tx			= null;
+		    this.promise_preauth		= null;
 		    // this.$store.dispatch('decline_promise', {
 		    // })
 		},

--- a/js/home.html
+++ b/js/home.html
@@ -31,52 +31,56 @@
 		<tr class="table-grouping-title">
 		    <th colspan="3"><mdc-subheading class="m-1">Pending</mdc-subheading></th>
 		</tr>
-		<tr v-for="(tx, index) in pending.requests" :key="tx.event[0]">
+		<!--
+		  -- Each preath has an event: (<commit>, <timestamp>, <entry>), and a provenance: [<agent-id>, <signature>].
+		  -- This data is ultimately used to construct a HoloFuel Zome `promise` or `receive_payment` call.
+		  -->
+		<tr v-for="(preauth, index) in pending.requests" :key="preauth.event[0]">
 		    <td style="width: 60%">
 			<mdc-body>
-			    <b>{{ datetime( tx.event[1], 'long' ) }}</b><br>
-			    {{ tx.event[2].Request.to }}<br>
-			    {{ tx.event[2].Request.notes }}
+			    <b>{{ datetime( preauth.event[1], 'long' ) }}</b><br>
+			    {{ preauth.event[2].Request.to }}<br>
+			    {{ preauth.event[2].Request.notes }}
 			</mdc-body>
 
 			<div class="flex-table">
 			    <div>
-				<mdc-button dense raised @click="dialog_request_confirm( tx )">Send</mdc-button>
+				<mdc-button dense raised @click="dialog_request_confirm( preauth )">Send</mdc-button>
 			    </div>				
 			    <div style="text-align: right;">
-				<mdc-button dense outlined @click="dialog_request_decline( tx )">Decline</mdc-button>
+				<mdc-button dense outlined @click="dialog_request_decline( preauth )">Decline</mdc-button>
 			    </div>
 			</div>
 		    </td>
 		    <td style="width: 20%; text-align: right;"></td>
 		    <td style="width: 20%; text-align: right;">
 			<mdc-body style="color: #C00;">
-			    <hf-symbol />{{ pending_request_amount( tx ) | currency }}
+			    <hf-symbol />{{ pending_request_amount( preauth ) | currency }}
 			    <br>
-			    <small>Fee {{ pending_request_fees( tx ) | currency }}</small>
+			    <small>Fee {{ pending_request_fees( preauth ) | currency }}</small>
 			</mdc-body>
 		    </td>
 		</tr>
-		<tr v-for="(tx, index) in pending.promises" :key="tx.event[0]">
+		<tr v-for="(preauth, index) in pending.promises" :key="preauth.event[0]">
 		    <td style="width: 60%">
 			<mdc-body>
-			    <b>{{ datetime( tx.event[1], 'long' ) }}</b><br>
-			    {{ tx.event[2].Promise.tx.from }}<br>
-			    {{ tx.event[2].Promise.tx.notes }}
+			    <b>{{ datetime( preauth.event[1], 'long' ) }}</b><br>
+			    {{ preauth.event[2].Promise.tx.from }}<br>
+			    {{ preauth.event[2].Promise.tx.notes }}
 			</mdc-body>
 
 			<div class="flex-table">
 			    <div>
-				<mdc-button dense raised @click="dialog_promise_confirm( tx )">Receive</mdc-button>
+				<mdc-button dense raised @click="dialog_promise_confirm( preauth )">Receive</mdc-button>
 			    </div>				
 			    <div style="text-align: right;">
-				<mdc-button dense outlined @click="dialog_promise_decline( tx )">Decline</mdc-button>
+				<mdc-button dense outlined @click="dialog_promise_decline( preauth )">Decline</mdc-button>
 			    </div>
 			</div>
 		    </td>
 		    <td style="width: 20%; text-align: right;">
 			<mdc-body style="color: #0C0;">
-			    <hf-symbol />{{ pending_promise_amount( tx ) | currency }}
+			    <hf-symbol />{{ pending_promise_amount( preauth ) | currency }}
 			</mdc-body>
 		    </td>
 		    <td style="width: 20%; text-align: right;"></td>
@@ -86,6 +90,17 @@
 		<tr class="table-grouping-title">
 		    <th colspan="3"><mdc-subheading class="m-1">Transactions</mdc-subheading></th>
 		</tr>
+		<!--
+		  -- Each tx has:
+		  --   .index	   Ordinal index of this transaction, eg. 115th
+		  --   .state	   Description, eg. "incoming/accepted"
+		  --   .origin	   Address of commit that originated the transaction
+		  --   .event	   This entry in the transaction
+		  --   .timestamp
+		  --	 .origin   Original entry's time
+		  --	 .event	   This event's time
+		  --   .adjustment The net change to the Ledger produced by transaction, so far
+		  -->
 		<tr v-for="tx in transactions" :key="tx.index">
 		    <td style="width: 60%">
 			<mdc-body>
@@ -169,39 +184,39 @@
 	</table>	
     </section>
 
-    <div v-if="request_tx">
+    <div v-if="request_preauth">
 	<mdc-dialog v-model="dialog_request_confirm_open"
 		    title="Approve requested funds"
 		    accept="Yes, send funds" cancel="Cancel"
-		    @accept="send_promise_for_request( request_tx )">
-	    Are you sure you want to send <hf-symbol />{{ request_tx.event[2].Request.amount | currency }}
-	    to {{ request_tx.event[2].Request.to }}?
+		    @accept="send_promise_for_request( request_preauth )">
+	    Are you sure you want to send <hf-symbol />{{ request_preauth.event[2].Request.amount | currency }}
+	    to {{ request_preauth.event[2].Request.to }}?
 	</mdc-dialog>
 	
 	<mdc-dialog v-model="dialog_request_decline_open"
 		    title="Decline requested funds"
 		    accept="Yes, decline request" cancel="Cancel"
-		    @accept="send_decline_for_request( request_tx )">
-	    Are you sure you want to decline the request from {{ request_tx.event[2].Request.to }}
-	    for <hf-symbol />{{ request_tx.event[2].Request.amount | currency }}?
+		    @accept="send_decline_for_request( request_preauth )">
+	    Are you sure you want to decline the request from {{ request_preauth.event[2].Request.to }}
+	    for <hf-symbol />{{ request_preauth.event[2].Request.amount | currency }}?
 	</mdc-dialog>
     </div>
     
-    <div v-if="promise_tx">
+    <div v-if="promise_preauth">
 	<mdc-dialog v-model="dialog_promise_confirm_open"
 		    title="Receive promised funds"
 		    accept="Yes, accept funds" cancel="Cancel"
-		    @accept="send_receive_payment( promise_tx )">
-	    Are you sure you want accept <hf-symbol />{{ promise_tx.event[2].Promise.tx.amount | currency }}
-	    from {{ promise_tx.event[2].Promise.tx.from }}?
+		    @accept="send_receive_payment( promise_preauth )">
+	    Are you sure you want accept <hf-symbol />{{ promise_preauth.event[2].Promise.tx.amount | currency }}
+	    from {{ promise_preauth.event[2].Promise.tx.from }}?
 	</mdc-dialog>
 	
 	<mdc-dialog v-model="dialog_promise_decline_open"
 		    title="Decline promiseed funds"
 		    accept="Yes, decline promise" cancel="Cancel"
-		    @accept="send_decline_payment( promise_tx )">
-	    Are you sure you want to decline the funds from {{ promise_tx.event[2].Promise.tx.from }}
-	    for <hf-symbol />{{ promise_tx.event[2].Promise.tx.amount | currency }}?
+		    @accept="send_decline_payment( promise_preauth )">
+	    Are you sure you want to decline the funds from {{ promise_preauth.event[2].Promise.tx.from }}
+	    for <hf-symbol />{{ promise_preauth.event[2].Promise.tx.amount | currency }}?
 	</mdc-dialog>
     </div>
     


### PR DESCRIPTION
o The preauths deliver different data than the `list_transactions` tx,
  so distinguish them from eachother in the various internal APIs
o Get the Promise signature from the preauth.provenance
o Document what's available in the preauth vs. the tx.